### PR TITLE
Added the possibility to create a container chain

### DIFF
--- a/src/ContainerChain.php
+++ b/src/ContainerChain.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Acclimate\Container;
+
+use Interop\Container\ContainerInterface;
+
+/**
+ * Class ContainerChain
+ *
+ * A container that delegates to a designated secondary container if the primary container does not contain
+ * the requested entry.
+ * @package Acclimate\Container
+ */
+final class ContainerChain implements ContainerInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $primary;
+    /**
+     * @var ContainerInterface
+     */
+    private $secondary;
+
+    /**
+     * ContainerChain constructor.
+     *
+     * @param ContainerInterface $primary
+     * @param ContainerInterface $secondary
+     */
+    public function __construct(ContainerInterface $primary, ContainerInterface $secondary)
+    {
+        $this->primary = $primary;
+        $this->secondary = $secondary;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($id)
+    {
+        if ($this->primary->has($id)) {
+            return $this->primary->get($id);
+        } else {
+            return $this->secondary->get($id);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($id)
+    {
+        return $this->primary->has($id) || $this->secondary->has($id);
+    }
+
+    /**
+     * Create a new container chain from the given containers in order.
+     *
+     * @param array $containers the containers to chain
+     * @return ContainerInterface
+     */
+    public static function create(array $containers)
+    {
+        switch (count($containers)) {
+            case 0:
+                return EmptyContainer::instance();
+            case 1:
+                return $containers[0];
+            default:
+                $container = EmptyContainer::instance();
+                /** @var ContainerInterface $previous */
+                foreach (array_reverse($containers) as $previous) {
+                    $container = new self($previous, $container);
+                }
+                return $container;
+        }
+    }
+}

--- a/src/EmptyContainer.php
+++ b/src/EmptyContainer.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Acclimate\Container;
+
+use Acclimate\Container\Exception\NotFoundException;
+use Interop\Container\ContainerInterface;
+
+/**
+ * Class EmptyContainer
+ *
+ * An immutable container which has no elements.
+ * @package Acclimate\Container
+ */
+final class EmptyContainer implements ContainerInterface
+{
+    private static $instance;
+
+    private function __construct()
+    {
+    }
+
+    private function __clone()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($id)
+    {
+        throw NotFoundException::fromPrevious($id);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($id)
+    {
+        return false;
+    }
+
+    public static function instance()
+    {
+        if (self::$instance === null) {
+            self::$instance = new EmptyContainer();
+        }
+        return self::$instance;
+    }
+}

--- a/tests/ContainerChainTest.php
+++ b/tests/ContainerChainTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Acclimate\Container\Test;
+
+
+use Acclimate\Container\ArrayContainer;
+use Acclimate\Container\ContainerChain;
+
+class ContainerChainTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCreateZero()
+    {
+        // when
+        $container = ContainerChain::create(array());
+
+        // then
+        $this->assertInstanceOf('Interop\Container\ContainerInterface', $container);
+    }
+
+    public function testHasAndGet()
+    {
+        // given
+        $first = new ArrayContainer(array('foo' => 'foo'));
+        $second = new ArrayContainer(array('xyz' => 'xyz'));
+
+        // when
+        $container = ContainerChain::create(array($first, $second));
+
+        // then
+        $this->assertTrue($container->has('foo'));
+        $this->assertTrue($container->has('xyz'));
+    }
+
+    public function testResponsibilityOrder()
+    {
+        // given
+        $first = new ArrayContainer(array('foo' => 'foo'));
+        $second = new ArrayContainer(array('xyz' => 'xyz', 'foo' => 'bar'));
+
+        // when
+        $container = ContainerChain::create(array($first, $second));
+
+        // then
+        $this->assertEquals($container->get('foo'), 'foo');
+        $this->assertEquals($container->get('xyz'), 'xyz');
+    }
+}

--- a/tests/EmptyContainerTest.php
+++ b/tests/EmptyContainerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Acclimate\Container\Test;
+
+
+use Acclimate\Container\EmptyContainer;
+
+class EmptyContainerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testInstantiation()
+    {
+        // when
+        $container = EmptyContainer::instance();
+
+        // then
+        $this->assertInstanceOf('Interop\Container\ContainerInterface', $container);
+    }
+
+    public function testHas()
+    {
+        // given
+        $container = EmptyContainer::instance();
+
+        // when
+        $hasFoo = $container->has('foo');
+
+        // then
+        $this->assertFalse($hasFoo);
+    }
+
+    /**
+     * @expectedException \Interop\Container\Exception\NotFoundException
+     */
+    public function testGet()
+    {
+        // given
+        $container = EmptyContainer::instance();
+
+        // when
+        $container->get('foo');
+
+        // then
+        $this->fail('unreachable');
+    }
+}


### PR DESCRIPTION
This similar to a composite container, but uses a chain-of-reponsibility pattern to implement composition. Why? The main benefit is that it's not using iteration to find the container responsible for the given id.
The chain is also able to replace the FailoverOnMissContainer if has() works as expected. Using exceptions for for control flow is an anti-pattern.
