### PR TITLE
Add static constructor for acclimator

### DIFF
--- a/src/ContainerAcclimator.php
+++ b/src/ContainerAcclimator.php
@@ -17,6 +17,20 @@ class ContainerAcclimator
     private $adapterMap;
 
     /**
+     * Create an adaptor statically for a particular container.
+     *
+     * @param mixed $container A third-party object to be acclimated
+     * @param array|null $customAdapterMap An optional adapter map to pass to the acclimator
+     * @return ContainerInterface
+     */
+    public static function acclimateContainer($container, array $customAdapterMap = null)
+    {
+        $acclimator = new self($customAdapterMap);
+
+        return $acclimator->acclimate($container);
+    }
+
+    /**
      * @param array $customAdapterMap Overwrite the predefined adapter map
      */
     public function __construct(array $customAdapterMap = null)

--- a/tests/ContainerAcclimatorTest.php
+++ b/tests/ContainerAcclimatorTest.php
@@ -50,7 +50,6 @@ class ContainerAcclimatorTest extends TestCase
         $pimpleContainer = $this->getMockBuilder(Pimple::class)->getMock();
         $container = ContainerAcclimator::acclimateContainer($pimpleContainer);
         $this->assertInstanceOf(ContainerInterface::class, $container);
-
     }
 
     public function testThrowsExceptionOnContainersThatCannotBeAdpated()

--- a/tests/ContainerAcclimatorTest.php
+++ b/tests/ContainerAcclimatorTest.php
@@ -45,6 +45,14 @@ class ContainerAcclimatorTest extends TestCase
         $this->assertInstanceOf(ContainerInterface::class, $container);
     }
 
+    public function testCreateAcclimatedContainerStatically()
+    {
+        $pimpleContainer = $this->getMockBuilder(Pimple::class)->getMock();
+        $container = ContainerAcclimator::acclimateContainer($pimpleContainer);
+        $this->assertInstanceOf(ContainerInterface::class, $container);
+
+    }
+
     public function testThrowsExceptionOnContainersThatCannotBeAdpated()
     {
         $acclimator = new ContainerAcclimator();


### PR DESCRIPTION
I found that once I had registered my given framework's DI implementation with Acclimate, I didn't need the acclimator that often afterward, and also during testing, where it was just another step in setup. I found myself pining for 'Acclimator::doYourThing($pimple)` and just getting back the adapted DI.