### PR TITLE
Fix: Keep packages sorted

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,9 @@
             "role": "Developer"
         }
     ],
+    "config": {
+        "sort-packages": true
+    },
     "require": {
         "php": ">=5.3.0",
         "container-interop/container-interop": "^1.0"
@@ -18,8 +21,8 @@
     "require-dev": {
         "php": ">=5.4.0",
         "aura/di": "^1.0",
-        "illuminate/container": "^4.0 || ^5.0",
         "guzzle/service": "^3.0",
+        "illuminate/container": "^4.0 || ^5.0",
         "league/container": "^1.0",
         "mnapoli/php-di": "^3.0",
         "nette/nette": "^2.1",


### PR DESCRIPTION
This PR

* [x] keeps packages sorted in `composer.json`

💁‍♂️ For reference, see https://getcomposer.org/doc/06-config.md#sort-packages.